### PR TITLE
solucion problema tareas y grupos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2475,6 +2475,14 @@
         "@types/react-router": "*"
       }
     },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^12.20.4",
     "@types/react-dom": "^17.0.1",
+    "@types/react-test-renderer": "^17.0.1",
     "@types/styled-components": "^5.1.7",
     "formik": "^2.2.6",
     "react": "^17.0.1",

--- a/src/components/addComponent/AddComponent.tsx
+++ b/src/components/addComponent/AddComponent.tsx
@@ -7,15 +7,17 @@ import InputButton from "../form/button/Button.style";
 interface AddTaskProps {
     addTask: AddNewTask;
     edit: boolean;
+    title: string;
  }
 
-const AddComponent: React.FC<AddTaskProps> = ({addTask, edit}) => {
+const AddComponent: React.FC<AddTaskProps> = ({addTask, edit, title}) => {
 
 
 const initialValues: Todo = {
     titulo: "",
     descripcion: "",
     completed:false,
+    group: ""
 }
 
 
@@ -28,7 +30,8 @@ return (
         addTask({
             titulo: data.titulo,
             descripcion: data.descripcion,
-            completed: false
+            completed: false,
+            group: title
         })
         setSubmitting(false)
         resetForm()

--- a/src/components/navbar/Navbar.styles.tsx
+++ b/src/components/navbar/Navbar.styles.tsx
@@ -2,25 +2,25 @@ import styled from "styled-components"
 
 export const NavbarContainer =  styled.nav`
     width: 100%;
-    border-bottom: 0.5px solid black;
+    border-bottom: 0.5px dashed rgba(0,0,0,0.35);
     display: flex;
     justify-content: space-around;
     align-items: center;
     padding: 1rem 1.5rem;
     text-align: center;
-
 `;
 
 export const Title = styled.h1`
+    padding:0 1rem;
     font-size: 1.5rem;
     text-transform: uppercase;
-  
+    border-left: 0.5px dashed rgba(0,0,0,0.35);
+    border-right: 0.5px dashed rgba(0,0,0,0.35);
 `;
 
 export const Div = styled.div`
     display: flex;
     position: relative;
-   
 `;
 
 export const P = styled.p`

--- a/src/components/navbar/Navbar.test.tsx
+++ b/src/components/navbar/Navbar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from "react-dom";
 import { render, screen } from '@testing-library/react';
 import Navbar from './Navbar';
 

--- a/src/group/groupComponent.tsx
+++ b/src/group/groupComponent.tsx
@@ -15,6 +15,8 @@ interface IGroupProps {
 }
 
 function Group( { title, taskList, editState, taskOperations, ...props } : IGroupProps  ) {
+let newTaskList:Todo[];
+newTaskList = taskList.filter((item)=> item.group === title)
 
     return (
         <>
@@ -25,16 +27,19 @@ function Group( { title, taskList, editState, taskOperations, ...props } : IGrou
                     <AddComponent 
                         edit={!editState}
                         addTask={taskOperations.addTask}
+                        title={title}
                     />
                     { 
-                        taskList.map( (item : Todo, idx : number) => 
+                        newTaskList?.map( (item : Todo, idx : number) => 
+                            
+                                <TaskComponent
+                                key={idx}
+                                task={item}
+                                removeTask={taskOperations.removeTask}
+                                toggleCompleted={taskOperations.toggleCompleted}/>
+                           )  
+                     
                         
-                        <TaskComponent
-                            key={idx}
-                            task={item}
-                            removeTask={taskOperations.removeTask}
-                            toggleCompleted={taskOperations.toggleCompleted}/>
-                        ) 
                     }
                 </CustomStyles.List>
             </CustomStyles.Card>

--- a/src/group/groupViewModel.tsx
+++ b/src/group/groupViewModel.tsx
@@ -12,6 +12,7 @@ function GroupVM(){
     const [edit, setEdit] = useState<boolean>(false);
   
     const addTask: AddNewTask = (newTask: Todo)=>{
+      console.log(newTask)
     setTasklist([
       ...taskList,
       newTask
@@ -19,7 +20,7 @@ function GroupVM(){
     }
   
     const removeTask: RemoveTask = (task:Todo)=> {
-      console.log("removiendo")
+     
       const newTaskList = taskList.filter(item => item.titulo !== task.titulo);
       setTasklist(newTaskList);
     }
@@ -43,7 +44,8 @@ function GroupVM(){
 
     const newGroupHandler = ( values : INewGroupParams ) => { 
         setGroups([...groupList, values.title ])
-        console.log("dadsad");
+        //const getNewList = taskList.filter((item)=> item.group === values.title)
+        //setTasklist(getNewList)
     }
 
     return (

--- a/src/testGuide.test.tsx
+++ b/src/testGuide.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import * as  ReactDOM from "react-dom";
+import { render, cleanup } from '@testing-library/react';
+import Navbar from "./components/navbar/Navbar";
+//import 'jest-dom/extend-expect'
+
+import renderer from 'react-test-renderer';
+
+
+//probar que el componente se renderiza. nota: preguntar sobre el div??.
+//usando getByTestId permite acceder a un elemento segun un atributo especial llamado data-testId = "nombre cualquiera"
+afterEach(cleanup);
+
+describe("renders Navbnar", ()=> {
+    test('renders Navbar react-dom', () => {
+        const div = document.createElement("div");
+        ReactDOM.render(<Navbar />, div);
+
+      });
+    test('renders Navbar react-testing-library', () => {
+        render(<Navbar />);
+      });
+//probar que muestra un determinado texto:
+
+//test("renders the correct content", ()=>{
+//  const root = document.createElement("div");
+//  ReactDOM.render(<Navbar />, root);
+//  expect(root.querySelector("h1")?.textContent).toBe("Usuario");
+
+  //usando @testing-library/dom
+
+  // const {getByText, getByLabelText} = getQueriesForElement(root)
+  //expect(getByText("Usuarios")).noT.toBeNull();
+
+
+
+     // it("renders correctly", ()=>{
+     //   const {getByTestId} = render(<Navbar/>)
+     //   expect(getByTestId("nombrex").toHaveTextContent("click me please"));
+     // })
+     //no reconoce toHaveTextContent
+
+     //it("matches snapshot", ()=>{
+     //   const tree = renderer.create(<Navbar/>).toJSON();
+     //   expect(tree).toMatchSnapshot();
+     //})
+     //no reconoce la importacion
+
+})

--- a/src/utils/defaultTask.tsx
+++ b/src/utils/defaultTask.tsx
@@ -2,12 +2,14 @@ export const defaultTask: Array<Todo> = [
     {
         titulo: "trelllo con miguel",
         descripcion: "algo que hacer",
-        completed: false
+        completed: false,
+        group: "cocina"
     },
     {
         titulo: "hablar con jose luis",
         descripcion: "algo que hacer",
-        completed:false
+        completed:false,
+        group: "hogar"
     },
 ];
 

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -3,6 +3,7 @@ type Todo = {
     titulo: string;
     descripcion: string;
     completed: boolean;
+    group: string;
 };
 
 type AddNewTask = (newTask:Todo)=> void;


### PR DESCRIPTION
En esta tarea se soluciona lo siguiente:
-Al crear el grupo de tareas se agregaban todas al mismo, al crear grupos nuevos se repetían las mismas tareas en todos.

Como probarlo:
-acceder a la app como de costumbre y proceder a cerar un grupo y luego crear tareas dentro del mismo.
si se crear el grupo cocina u hogar se observara una de las dos tareas que hay por defecto como prueba.